### PR TITLE
feat: add exec apis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(hyprlua SHARED
   src/lua/runtime.cpp
   src/lua/monitors.cpp
   src/lua/keybinds.cpp
+  src/lua/exec.cpp
 )
 
 # Include directories

--- a/README.md
+++ b/README.md
@@ -30,6 +30,82 @@ end)
 
 The plugin watches your config file and hot-reloads on save.
 
+## Available Features
+
+### Monitors (`hypr.monitors`)
+
+| Function | Description |
+|---|---|
+| `hypr.monitors.add(name, resolution, position, scale, workspaces?)` | Configure a monitor |
+| `hypr.monitors.disable(name)` | Disable a monitor |
+
+- `name` — Monitor identifier (e.g. `"DP-2"`, `"desc:LG Electronics 0x1234"`)
+- `resolution` — `"WxH@Hz"`, `"WxH"`, or `"preferred"`
+- `position` — `"XxY"` or `"auto"`
+- `scale` — Scaling factor (e.g. `1`, `1.5`)
+- `workspaces` — Optional list of workspace IDs to assign (e.g. `{ 1, 2, 3 }`)
+
+```lua
+hypr.monitors.add("DP-2", "1920x1200@60.00Hz", "0x0", 1, { 1, 2 })
+hypr.monitors.add("eDP-1", "preferred", "auto", 1.5)
+hypr.monitors.disable("HDMI-A-1")
+```
+
+### Keybinds (`hypr.binds`)
+
+| Function | Description |
+|---|---|
+| `hypr.binds.set(mods, key, dispatcher, args, opts?)` | Bind a key combination |
+| `hypr.binds.submap(name, fn)` | Define a submap with grouped binds |
+
+- `mods` — Modifier keys (e.g. `"SUPER"`, `"SUPER SHIFT"`)
+- `key` — Key name (e.g. `"Return"`, `"h"`, `"catchall"`)
+- `dispatcher` — Hyprland dispatcher (e.g. `"exec"`, `"movefocus"`, `"killactive"`)
+- `args` — Dispatcher arguments
+- `opts` — Optional table:
+  - `flags` — String of flag characters: `l` (locked), `r` (release), `e` (repeat), `m` (mouse), `n` (non-consuming), `t` (transparent), `i` (ignore mods)
+  - `submap` — Register the bind in a named submap
+
+```lua
+local bind = hypr.binds.set
+
+bind("SUPER", "Return", "exec", "alacritty")
+bind("SUPER", "w", "killactive", "")
+bind("SUPER SHIFT", "h", "resizeactive", "-50 0", { flags = "e" })
+
+-- Mouse binds
+bind("SUPER", "mouse:272", "movewindow", "", { flags = "m" })
+
+-- Submaps (auto-appends catchall reset bind)
+hypr.binds.submap("open", function(b)
+    b("SUPER", "f", "exec", "nautilus")
+    b("SUPER", "s", "exec", "spotify-launcher")
+end)
+```
+
+### Exec (`hypr.exec`)
+
+| Function | Description |
+|---|---|
+| `hypr.exec(cmd)` | Spawn a process every time the config is evaluated |
+| `hypr.exec_once(cmd)` | Spawn a process only once per Hyprland session |
+| `hypr.exec_on_load(cmd)` | Spawn a process once per plugin load (not on hot-reloads) |
+
+- `hypr.exec(cmd)` — Runs on every config load/reload. Use for commands that are safe to repeat.
+- `hypr.exec_once(cmd)` — Runs only once per Hyprland session, even across plugin reloads. Tracked via a flag file in `$XDG_RUNTIME_DIR`.
+- `hypr.exec_on_load(cmd)` — Runs once when the plugin is loaded via `hyprctl plugin load`, but not on config hot-reloads.
+
+```lua
+-- Start a wallpaper daemon once per session
+hypr.exec_once("hyprpaper")
+
+-- Launch a bar on plugin load (restarts if plugin is reloaded)
+hypr.exec_on_load("waybar")
+
+-- Run on every config evaluation
+hypr.exec("notify-send 'Config loaded'")
+```
+
 ## Installation
 
 ### AUR (Arch Linux)

--- a/runtime/modules/exec.lua
+++ b/runtime/modules/exec.lua
@@ -1,0 +1,37 @@
+--- Exec Module
+--- Process spawning with session-once and plugin-load-once semantics.
+--- Exposes `hypr.exec()`, `hypr.exec_once()`, and `hypr.exec_on_load()` on the hypr global.
+--- @module exec
+
+-- luacheck: push ignore 113 112
+function hypr.exec(cmd)
+	assert(type(cmd) == "string", "exec: cmd must be a string")
+	if __hypr_exec then
+		__hypr_exec(cmd)
+	else
+		error("__hypr_exec is not defined in Lua runtime")
+	end
+end
+
+--- Fires once per Hyprland session, identified by HYPRLAND_INSTANCE_SIGNATURE.
+--- Reloading the plugin within the same Hyprland session will NOT re-run this.
+function hypr.exec_once(cmd)
+	assert(type(cmd) == "string", "exec_once: cmd must be a string")
+	if __hypr_exec_once then
+		__hypr_exec_once(cmd)
+	else
+		error("__hypr_exec_once is not defined in Lua runtime")
+	end
+end
+
+--- Fires once every time the plugin is loaded or reloaded via hyprctl.
+--- Does NOT fire on config file hot-reloads.
+function hypr.exec_on_load(cmd)
+	assert(type(cmd) == "string", "exec_on_load: cmd must be a string")
+	if __hypr_exec_on_load then
+		__hypr_exec_on_load(cmd)
+	else
+		error("__hypr_exec_on_load is not defined in Lua runtime")
+	end
+end
+-- luacheck: pop

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -13,20 +13,27 @@
 #include <cstdlib>
 #include <execinfo.h>
 #include <signal.h>
-#include <cstring>
+#include <unistd.h>
 
 namespace hyprlua::log {
 
     inline std::ofstream& stream() {
         static std::ofstream file([] {
-            // Prefer XDG_RUNTIME_DIR to avoid symlink attacks on /tmp
+            // Follow Hyprland's convention: logs go in
+            // $XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/
+            // alongside hyprland.log. The directory is created by Hyprland at startup.
             const char* xdgRuntime = std::getenv("XDG_RUNTIME_DIR");
-            std::string path       = xdgRuntime ? std::string(xdgRuntime) + "/hyprlua.log" : "/tmp/hyprlua.log";
+            const char* sig        = std::getenv("HYPRLAND_INSTANCE_SIGNATURE");
+
+            std::string path;
+            if (xdgRuntime && sig)
+                path = std::string(xdgRuntime) + "/hypr/" + sig + "/hyprlua.log";
+            else
+                path = "/tmp/hyprlua.log"; // fallback when running outside Hyprland
+
             std::ofstream f(path, std::ios::app);
-            if (!f.is_open()) {
-                // Fallback: stderr if the log file cannot be opened
+            if (!f.is_open())
                 return std::ofstream{};
-            }
             return f;
         }());
         return file;
@@ -61,16 +68,18 @@ namespace hyprlua::log {
     }
 
     inline void crash_handler(int sig) {
-        void*  frames[64];
-        int    n    = backtrace(frames, 64);
-        char** syms = backtrace_symbols(frames, n);
+        // This handler must use only async-signal-safe functions (see signal-safety(7)).
+        // malloc, std::string, std::mutex, and backtrace_symbols are NOT safe here —
+        // they can deadlock if the signal fires while their internal locks are held.
+        void* frames[64];
+        int   n = backtrace(frames, 64);
 
-        write("FATAL", "Caught signal " + std::to_string(sig) + " (" + strsignal(sig) + ")");
-        if (syms) {
-            for (int i = 0; i < n; ++i)
-                write("FATAL", "  " + std::string(syms[i]));
-            free(syms);
-        }
+        // backtrace_symbols_fd writes directly to an fd with no heap allocation.
+        // STDERR_FILENO is always open and async-signal-safe to write to.
+        const char header[] = "hyprlua: fatal signal, backtrace:\n";
+        ::write(STDERR_FILENO, header, sizeof(header) - 1);
+        backtrace_symbols_fd(frames, n, STDERR_FILENO);
+
         // Re-raise to let the default handler produce core dump / Hyprland secure mode
         signal(sig, SIG_DFL);
         raise(sig);

--- a/src/lua/exec.cpp
+++ b/src/lua/exec.cpp
@@ -1,0 +1,105 @@
+#include "lua/exec.hpp"
+#include "logger.hpp"
+
+#include <spawn.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <atomic>
+#include <cstring>
+#include <string>
+
+extern char** environ;
+
+namespace hyprlua::modules {
+
+    // Set to false after the first successful config run per plugin load.
+    // Never reset on hot-reload, so exec_on_load does not re-fire.
+    static std::atomic<bool> g_plugin_load{true};
+
+    static void spawn(const std::string& cmd) {
+        const char* shell = getenv("SHELL");
+        if (!shell || shell[0] == '\0')
+            shell = "sh"; // resolved via PATH, no hardcoded location
+
+        log::info("exec: spawning via " + std::string(shell) + ": " + cmd);
+
+        const char* argv[] = {shell, "-c", cmd.c_str(), nullptr};
+
+        // Reset all caught signals to SIG_DFL and clear the signal mask in the
+        // child so the spawned shell does not inherit compositor signal dispositions.
+        posix_spawnattr_t attr;
+        posix_spawnattr_init(&attr);
+        posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK);
+
+        sigset_t empty;
+        sigemptyset(&empty);
+        posix_spawnattr_setsigmask(&attr, &empty);
+
+        sigset_t all;
+        sigfillset(&all);
+        posix_spawnattr_setsigdefault(&attr, &all);
+
+        pid_t pid;
+        // Hyprland sets SA_NOCLDWAIT in main(), so children are auto-reaped.
+        // posix_spawnp searches PATH for the shell binary.
+        int ret = posix_spawnp(&pid, shell, nullptr, &attr, const_cast<char* const*>(argv), environ);
+        posix_spawnattr_destroy(&attr);
+
+        if (ret != 0) {
+            char buf[64];
+            strerror_r(ret, buf, sizeof(buf));
+            log::error("exec: posix_spawnp failed: " + std::string(buf));
+        }
+    }
+
+    // Returns true and creates the flag file if this is the first hyprlua run for
+    // the current Hyprland session (identified by HYPRLAND_INSTANCE_SIGNATURE).
+    // The flag file lives in XDG_RUNTIME_DIR and is cleaned up when the session ends.
+    static bool claim_session_start() {
+        const char* sig = getenv("HYPRLAND_INSTANCE_SIGNATURE");
+        if (!sig || sig[0] == '\0') {
+            log::error("exec_once: HYPRLAND_INSTANCE_SIGNATURE not set, cannot determine session");
+            return false;
+        }
+
+        const char* xdg = getenv("XDG_RUNTIME_DIR");
+        std::string flag_path = std::string(xdg ? xdg : "/tmp") + "/hyprlua-" + sig + ".once";
+
+        // O_CREAT|O_EXCL is atomic: succeeds only if the file did not exist.
+        // If it already exists (plugin reloaded within same Hyprland session), open fails.
+        int fd = open(flag_path.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0600);
+        if (fd < 0)
+            return false; // already started this session
+
+        close(fd);
+        log::info("exec_once: session flag created at " + flag_path);
+        return true;
+    }
+
+    void bind_exec(sol::state& lua) {
+        lua.set_function("__hypr_exec", [](const std::string& cmd) {
+            spawn(cmd);
+        });
+
+        lua.set_function("__hypr_exec_once", [](const std::string& cmd) {
+            if (claim_session_start())
+                spawn(cmd);
+            else
+                log::info("exec_once: skipping, already ran this session: " + cmd);
+        });
+
+        lua.set_function("__hypr_exec_on_load", [](const std::string& cmd) {
+            if (g_plugin_load)
+                spawn(cmd);
+            else
+                log::info("exec_on_load: skipping (not plugin load): " + cmd);
+        });
+    }
+
+    void mark_startup_done() {
+        g_plugin_load = false;
+        log::info("exec: plugin load phase complete, exec_on_load suppressed until next plugin load");
+    }
+
+} // namespace hyprlua::modules

--- a/src/lua/exec.hpp
+++ b/src/lua/exec.hpp
@@ -1,0 +1,17 @@
+/**
+ * @file exec.hpp
+ * @brief Process spawning module (Lua: __hypr_exec, __hypr_exec_once)
+ */
+#pragma once
+
+#include <sol/sol.hpp>
+
+namespace hyprlua::modules {
+
+    /// @brief Register exec functions into the Lua state
+    void bind_exec(sol::state& lua);
+
+    /// @brief Mark startup as done — exec_once will no longer spawn after this
+    void mark_startup_done();
+
+} // namespace hyprlua::modules

--- a/src/lua/runtime.cpp
+++ b/src/lua/runtime.cpp
@@ -10,6 +10,7 @@
 
 #include "lua/monitors.hpp"
 #include "lua/keybinds.hpp"
+#include "lua/exec.hpp"
 #include "utils.hpp"
 
 namespace hyprlua {
@@ -28,8 +29,8 @@ namespace hyprlua {
 
         lua.open_libraries(sol::lib::base, sol::lib::package, sol::lib::math, sol::lib::table, sol::lib::string, sol::lib::os);
 
-        // Restrict dangerous os functions — user config is trusted, but an attacker who can
-        // write to the modules path would otherwise gain arbitrary shell execution.
+        // Restrict dangerous os functions. User config is trusted; these are removed to
+        // limit accidental misuse (exec/exec_once are the intentional process-spawning API).
         lua["os"]["execute"] = sol::nil;
         lua["os"]["remove"]  = sol::nil;
         lua["os"]["rename"]  = sol::nil;
@@ -41,6 +42,7 @@ namespace hyprlua {
 
         hyprlua::modules::bind_monitors(lua);
         hyprlua::modules::bind_keybinds(lua);
+        hyprlua::modules::bind_exec(lua);
 
         auto names = modules::list_monitors();
         log::info("Hyprland reports these monitors:");
@@ -53,7 +55,7 @@ namespace hyprlua {
         lua["hypr"]["version"] = HYPRLUA_VERSION;
 
         try {
-            for (const auto& script : {"monitors.lua", "binds.lua"}) {
+            for (const auto& script : {"monitors.lua", "binds.lua", "exec.lua"}) {
                 std::string script_path = s_modules_path + "/" + script;
                 if (!fs::exists(script_path)) {
                     sendNotification("Module not found: " + script_path, CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
@@ -83,7 +85,12 @@ namespace hyprlua {
                 sol::error err = result;
                 log::error("Error executing config: " + std::string(err.what()));
                 sendNotification("Error executing: " + s_user_config_path, CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
+                // Do not mark startup done — exec_once should retry on the next
+                // successful load rather than being permanently suppressed.
+                return;
             }
+
+            hyprlua::modules::mark_startup_done();
 
         } catch (const std::exception& e) {
             log::error("Runtime initialization failed: " + std::string(e.what()));


### PR DESCRIPTION
## Summary

- Add `hypr.exec(cmd)`, `hypr.exec_once(cmd)`, and `hypr.exec_on_load(cmd)` APIs for spawning processes with different lifecycle semantics
- `exec_once` runs only once per Hyprland session (tracked via atomic flag file in `$XDG_RUNTIME_DIR`)
- `exec_on_load` runs once per plugin load but not on config hot-reloads
- Process spawning uses `posix_spawnp` with clean signal state inheritance


## Test plan

- [ ] `hypr.exec("notify-send 'test'")` runs on every config reload
- [ ] `hypr.exec_once("hyprpaper")` runs only once per session, even after plugin reload
- [ ] `hypr.exec_on_load("waybar")` runs on plugin load but not on config hot-reload
- [ ] Flag file is created at `$XDG_RUNTIME_DIR/hyprlua-<signature>.once`
- [ ] Child processes inherit clean signal state